### PR TITLE
Feature: Save Article from URL

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -20,7 +20,9 @@
       "Bash(gh issue view:*)",
       "Bash(gh api:*)",
       "Bash(git checkout:*)",
-      "Bash(dotnet test:*)"
+      "Bash(dotnet test:*)",
+      "Bash(gh issue close:*)",
+      "Bash(git commit -m \"$\\(cat <<''EOF''\nAdd article saving with content extraction from URLs\n\n- SmartReader \\(Mozilla Readability port\\) for extracting article content\n- URL validation \\(HTTP/HTTPS only\\), domain extraction\n- Duplicate detection: returns existing article if same URL saved again\n- Graceful degradation: saves stub article if parsing fails \\(IsContentParsed flag\\)\n- Word count + estimated reading time \\(200 wpm\\) calculated at save time\n- HttpClient configured with 30s timeout and 10MB limit\n- Article entity extended with WordCount, EstimatedReadingTimeMinutes, IsContentParsed\n- IArticleParser interface in Core, SmartReaderArticleParser in Infrastructure\n- Repository: added GetByUrlAsync for duplicate detection\n\nCloses #2\n\nCo-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>\nEOF\n\\)\")"
     ]
   }
 }

--- a/src/ReadWise.Api/Program.cs
+++ b/src/ReadWise.Api/Program.cs
@@ -7,6 +7,7 @@ using ReadWise.Api.Services;
 using ReadWise.Core.Entities;
 using ReadWise.Core.Interfaces;
 using ReadWise.Infrastructure.Data;
+using ReadWise.Infrastructure.Services;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -63,6 +64,12 @@ builder.Services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
 builder.Services.AddAuthorization();
 builder.Services.AddScoped<TokenService>();
 builder.Services.AddScoped<IArticleRepository, ArticleRepository>();
+builder.Services.AddHttpClient<IArticleParser, SmartReaderArticleParser>(client =>
+{
+    client.Timeout = TimeSpan.FromSeconds(30);
+    client.MaxResponseContentBufferSize = 10 * 1024 * 1024; // 10MB
+    client.DefaultRequestHeaders.UserAgent.ParseAdd("ReadWise/1.0");
+});
 
 var app = builder.Build();
 

--- a/src/ReadWise.Core/Entities/Article.cs
+++ b/src/ReadWise.Core/Entities/Article.cs
@@ -11,6 +11,9 @@ public class Article
     public string? Excerpt { get; set; }
     public string? ImageUrl { get; set; }
     public string? Domain { get; set; }
+    public int WordCount { get; set; }
+    public int EstimatedReadingTimeMinutes { get; set; }
+    public bool IsContentParsed { get; set; }
     public bool IsRead { get; set; }
     public bool IsArchived { get; set; }
     public bool IsFavorite { get; set; }

--- a/src/ReadWise.Core/Interfaces/IArticleParser.cs
+++ b/src/ReadWise.Core/Interfaces/IArticleParser.cs
@@ -1,0 +1,15 @@
+namespace ReadWise.Core.Interfaces;
+
+public record ParsedArticle(
+    string Title,
+    string? Author,
+    string? Content,
+    string? Excerpt,
+    string? ImageUrl,
+    int WordCount
+);
+
+public interface IArticleParser
+{
+    Task<ParsedArticle?> ParseAsync(string url);
+}

--- a/src/ReadWise.Core/Interfaces/IArticleRepository.cs
+++ b/src/ReadWise.Core/Interfaces/IArticleRepository.cs
@@ -5,6 +5,7 @@ namespace ReadWise.Core.Interfaces;
 public interface IArticleRepository
 {
     Task<Article?> GetByIdAsync(Guid id, string userId);
+    Task<Article?> GetByUrlAsync(string url, string userId);
     Task<IReadOnlyList<Article>> GetAllByUserAsync(string userId);
     Task<Article> AddAsync(Article article);
     Task UpdateAsync(Article article);

--- a/src/ReadWise.Infrastructure/Data/ArticleRepository.cs
+++ b/src/ReadWise.Infrastructure/Data/ArticleRepository.cs
@@ -19,6 +19,12 @@ public class ArticleRepository : IArticleRepository
             .FirstOrDefaultAsync(a => a.Id == id && a.UserId == userId);
     }
 
+    public async Task<Article?> GetByUrlAsync(string url, string userId)
+    {
+        return await _context.Articles
+            .FirstOrDefaultAsync(a => a.Url == url && a.UserId == userId);
+    }
+
     public async Task<IReadOnlyList<Article>> GetAllByUserAsync(string userId)
     {
         return await _context.Articles

--- a/src/ReadWise.Infrastructure/ReadWise.Infrastructure.csproj
+++ b/src/ReadWise.Infrastructure/ReadWise.Infrastructure.csproj
@@ -12,6 +12,7 @@
     </PackageReference>
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.2" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.2" />
+    <PackageReference Include="SmartReader" Version="0.11.0" />
   </ItemGroup>
 
   <PropertyGroup>

--- a/src/ReadWise.Infrastructure/Services/SmartReaderArticleParser.cs
+++ b/src/ReadWise.Infrastructure/Services/SmartReaderArticleParser.cs
@@ -1,0 +1,64 @@
+using System.Text.RegularExpressions;
+using ReadWise.Core.Interfaces;
+using SmartReader;
+
+namespace ReadWise.Infrastructure.Services;
+
+public partial class SmartReaderArticleParser : IArticleParser
+{
+    private readonly HttpClient _httpClient;
+
+    public SmartReaderArticleParser(HttpClient httpClient)
+    {
+        _httpClient = httpClient;
+    }
+
+    public async Task<ParsedArticle?> ParseAsync(string url)
+    {
+        try
+        {
+            var response = await _httpClient.GetAsync(url);
+            response.EnsureSuccessStatusCode();
+
+            var html = await response.Content.ReadAsStringAsync();
+            var reader = new Reader(url, html);
+            var article = reader.GetArticle();
+
+            if (!article.IsReadable)
+                return null;
+
+            var plainText = StripHtmlTags(article.TextContent ?? "");
+            var wordCount = CountWords(plainText);
+
+            return new ParsedArticle(
+                Title: article.Title ?? url,
+                Author: article.Author,
+                Content: article.Content,
+                Excerpt: article.Excerpt,
+                ImageUrl: article.FeaturedImage,
+                WordCount: wordCount
+            );
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    private static string StripHtmlTags(string html)
+    {
+        return HtmlTagPattern().Replace(html, " ").Trim();
+    }
+
+    private static int CountWords(string text)
+    {
+        if (string.IsNullOrWhiteSpace(text)) return 0;
+        return WhitespacePattern().Split(text.Trim()).Length;
+    }
+
+    [GeneratedRegex(@"<[^>]+>")]
+    private static partial Regex HtmlTagPattern();
+
+    [GeneratedRegex(@"\s+")]
+    private static partial Regex WhitespacePattern();
+}

--- a/src/web/src/types/article.ts
+++ b/src/web/src/types/article.ts
@@ -8,6 +8,9 @@ export interface Article {
   excerpt?: string;
   imageUrl?: string;
   domain?: string;
+  wordCount: number;
+  estimatedReadingTimeMinutes: number;
+  isContentParsed: boolean;
   isRead: boolean;
   isArchived: boolean;
   isFavorite: boolean;


### PR DESCRIPTION
## Summary
- Content extraction using SmartReader (.NET port of Mozilla Readability)
- URL validation, domain extraction, word count + estimated reading time
- Duplicate handling: returns existing article if same URL is saved again
- Graceful degradation: saves stub article with `IsContentParsed=false` if parsing fails
- HttpClient with 30s timeout and 10MB response limit

## Test plan
- [ ] Save a valid article URL (e.g., a Wikipedia or blog post)
- [ ] Verify title, author, content, excerpt are extracted
- [ ] Verify domain is extracted correctly
- [ ] Verify word count and reading time are calculated
- [ ] Submit an invalid URL (should get 400)
- [ ] Submit a duplicate URL (should return existing article)
- [ ] Submit a URL that can't be parsed (should save stub)

Closes #2

🤖 Generated with [Claude Code](https://claude.ai/code)