### PR TITLE
Feature: Reader View

### DIFF
--- a/src/web/src/hooks/useReaderPreferences.ts
+++ b/src/web/src/hooks/useReaderPreferences.ts
@@ -1,0 +1,95 @@
+import { useState, useEffect, useCallback } from 'react';
+
+export type ThemeMode = 'light' | 'dark' | 'system';
+
+interface ReaderPreferences {
+  fontSize: number;
+  theme: ThemeMode;
+}
+
+const PREFS_KEY = 'readwise_reader_prefs';
+const DEFAULT_PREFS: ReaderPreferences = { fontSize: 18, theme: 'system' };
+const MIN_FONT_SIZE = 14;
+const MAX_FONT_SIZE = 24;
+const FONT_STEP = 2;
+
+function loadPrefs(): ReaderPreferences {
+  try {
+    const stored = localStorage.getItem(PREFS_KEY);
+    if (stored) return { ...DEFAULT_PREFS, ...JSON.parse(stored) };
+  } catch { /* ignore */ }
+  return DEFAULT_PREFS;
+}
+
+function savePrefs(prefs: ReaderPreferences) {
+  localStorage.setItem(PREFS_KEY, JSON.stringify(prefs));
+}
+
+function getResolvedTheme(theme: ThemeMode): 'light' | 'dark' {
+  if (theme !== 'system') return theme;
+  return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+}
+
+export function useReaderPreferences() {
+  const [prefs, setPrefs] = useState(loadPrefs);
+  const [resolvedTheme, setResolvedTheme] = useState<'light' | 'dark'>(() =>
+    getResolvedTheme(prefs.theme)
+  );
+
+  useEffect(() => {
+    setResolvedTheme(getResolvedTheme(prefs.theme));
+
+    if (prefs.theme === 'system') {
+      const mq = window.matchMedia('(prefers-color-scheme: dark)');
+      const handler = (e: MediaQueryListEvent) => setResolvedTheme(e.matches ? 'dark' : 'light');
+      mq.addEventListener('change', handler);
+      return () => mq.removeEventListener('change', handler);
+    }
+  }, [prefs.theme]);
+
+  const update = useCallback((partial: Partial<ReaderPreferences>) => {
+    setPrefs((prev) => {
+      const next = { ...prev, ...partial };
+      savePrefs(next);
+      return next;
+    });
+  }, []);
+
+  const increaseFontSize = useCallback(() => {
+    setPrefs((prev) => {
+      const next = { ...prev, fontSize: Math.min(prev.fontSize + FONT_STEP, MAX_FONT_SIZE) };
+      savePrefs(next);
+      return next;
+    });
+  }, []);
+
+  const decreaseFontSize = useCallback(() => {
+    setPrefs((prev) => {
+      const next = { ...prev, fontSize: Math.max(prev.fontSize - FONT_STEP, MIN_FONT_SIZE) };
+      savePrefs(next);
+      return next;
+    });
+  }, []);
+
+  const cycleTheme = useCallback(() => {
+    setPrefs((prev) => {
+      const order: ThemeMode[] = ['light', 'dark', 'system'];
+      const idx = order.indexOf(prev.theme);
+      const next = { ...prev, theme: order[(idx + 1) % order.length] };
+      savePrefs(next);
+      return next;
+    });
+  }, []);
+
+  return {
+    fontSize: prefs.fontSize,
+    theme: prefs.theme,
+    resolvedTheme,
+    increaseFontSize,
+    decreaseFontSize,
+    cycleTheme,
+    canIncrease: prefs.fontSize < MAX_FONT_SIZE,
+    canDecrease: prefs.fontSize > MIN_FONT_SIZE,
+    update,
+  };
+}

--- a/src/web/src/hooks/useReadingProgress.ts
+++ b/src/web/src/hooks/useReadingProgress.ts
@@ -1,0 +1,23 @@
+import { useState, useEffect } from 'react';
+
+export function useReadingProgress(): number {
+  const [progress, setProgress] = useState(0);
+
+  useEffect(() => {
+    const handleScroll = () => {
+      const scrollTop = window.scrollY;
+      const docHeight = document.documentElement.scrollHeight - window.innerHeight;
+      if (docHeight <= 0) {
+        setProgress(100);
+        return;
+      }
+      setProgress(Math.min(100, Math.round((scrollTop / docHeight) * 100)));
+    };
+
+    window.addEventListener('scroll', handleScroll, { passive: true });
+    handleScroll();
+    return () => window.removeEventListener('scroll', handleScroll);
+  }, []);
+
+  return progress;
+}

--- a/src/web/src/pages/ReaderPage.tsx
+++ b/src/web/src/pages/ReaderPage.tsx
@@ -2,11 +2,29 @@ import { useEffect, useState } from 'react';
 import { useParams, Link } from 'react-router-dom';
 import type { Article } from '../types/article';
 import { articlesApi } from '../services/api';
+import { useReaderPreferences } from '../hooks/useReaderPreferences';
+import { useReadingProgress } from '../hooks/useReadingProgress';
+
+const themeStyles = {
+  light: { background: '#ffffff', color: '#1a1a1a', metaColor: '#666', controlBg: '#f5f5f5' },
+  dark: { background: '#1a1a1a', color: '#e0e0e0', metaColor: '#999', controlBg: '#2a2a2a' },
+};
+
+const themeLabels: Record<string, string> = {
+  light: 'Light',
+  dark: 'Dark',
+  system: 'System',
+};
 
 export function ReaderPage() {
   const { id } = useParams<{ id: string }>();
   const [article, setArticle] = useState<Article | null>(null);
   const [loading, setLoading] = useState(true);
+  const { fontSize, theme, resolvedTheme, increaseFontSize, decreaseFontSize, cycleTheme, canIncrease, canDecrease } =
+    useReaderPreferences();
+  const progress = useReadingProgress();
+
+  const colors = themeStyles[resolvedTheme];
 
   useEffect(() => {
     if (!id) return;
@@ -19,24 +37,128 @@ export function ReaderPage() {
       .finally(() => setLoading(false));
   }, [id]);
 
-  if (loading) return <p>Loading...</p>;
-  if (!article) return <p>Article not found.</p>;
+  if (loading) {
+    return (
+      <div style={{ ...colors, minHeight: '100vh', display: 'flex', justifyContent: 'center', alignItems: 'center' }}>
+        <p>Loading...</p>
+      </div>
+    );
+  }
+
+  if (!article) {
+    return (
+      <div style={{ ...colors, minHeight: '100vh', padding: '2rem', textAlign: 'center' }}>
+        <p>Article not found.</p>
+        <Link to="/">Back to articles</Link>
+      </div>
+    );
+  }
 
   return (
-    <article>
-      <Link to="/">Back</Link>
-      <h1>{article.title}</h1>
-      {article.author && <p>By {article.author}</p>}
-      {article.content ? (
-        <div dangerouslySetInnerHTML={{ __html: article.content }} />
-      ) : (
-        <p>
-          Content not yet parsed.{' '}
-          <a href={article.url} target="_blank" rel="noopener noreferrer">
-            Read on original site
-          </a>
-        </p>
-      )}
-    </article>
+    <div style={{ background: colors.background, color: colors.color, minHeight: '100vh' }}>
+      {/* Progress bar */}
+      <div
+        style={{
+          position: 'fixed',
+          top: 0,
+          left: 0,
+          height: 3,
+          width: `${progress}%`,
+          background: '#4a9eff',
+          transition: 'width 100ms ease-out',
+          zIndex: 1000,
+        }}
+      />
+
+      {/* Controls bar */}
+      <div
+        style={{
+          position: 'fixed',
+          top: 3,
+          left: 0,
+          right: 0,
+          background: colors.controlBg,
+          borderBottom: `1px solid ${resolvedTheme === 'dark' ? '#333' : '#ddd'}`,
+          padding: '0.5rem 1rem',
+          display: 'flex',
+          justifyContent: 'space-between',
+          alignItems: 'center',
+          zIndex: 999,
+          fontSize: '0.85rem',
+        }}
+      >
+        <Link to="/" style={{ color: colors.color, textDecoration: 'none' }}>
+          &larr; Back
+        </Link>
+        <div style={{ display: 'flex', gap: '0.75rem', alignItems: 'center' }}>
+          <button onClick={decreaseFontSize} disabled={!canDecrease} title="Decrease font size">
+            A-
+          </button>
+          <span>{fontSize}px</span>
+          <button onClick={increaseFontSize} disabled={!canIncrease} title="Increase font size">
+            A+
+          </button>
+          <button onClick={cycleTheme} title="Toggle theme">
+            {themeLabels[theme]}
+          </button>
+        </div>
+        <span style={{ color: colors.metaColor }}>{progress}%</span>
+      </div>
+
+      {/* Article content */}
+      <article
+        style={{
+          maxWidth: 680,
+          margin: '0 auto',
+          padding: '4rem 1.5rem 3rem',
+          fontFamily: 'Georgia, "Times New Roman", serif',
+          fontSize: `${fontSize}px`,
+          lineHeight: 1.8,
+        }}
+      >
+        <header style={{ marginBottom: '2rem' }}>
+          <h1
+            style={{
+              fontSize: `${fontSize * 1.6}px`,
+              lineHeight: 1.3,
+              fontWeight: 700,
+              marginBottom: '0.5rem',
+            }}
+          >
+            {article.title}
+          </h1>
+          <div style={{ color: colors.metaColor, fontSize: `${fontSize * 0.8}px` }}>
+            {article.author && <span>By {article.author}</span>}
+            {article.author && article.domain && <span> &middot; </span>}
+            {article.domain && <span>{article.domain}</span>}
+            {article.estimatedReadingTimeMinutes > 0 && (
+              <span> &middot; {article.estimatedReadingTimeMinutes} min read</span>
+            )}
+          </div>
+        </header>
+
+        {article.content && article.isContentParsed ? (
+          <div
+            className="reader-content"
+            dangerouslySetInnerHTML={{ __html: article.content }}
+            style={{ wordBreak: 'break-word' }}
+          />
+        ) : (
+          <div>
+            <p>This article's content could not be parsed for reader mode.</p>
+            <p>
+              <a
+                href={article.url}
+                target="_blank"
+                rel="noopener noreferrer"
+                style={{ color: '#4a9eff' }}
+              >
+                Read on the original site &rarr;
+              </a>
+            </p>
+          </div>
+        )}
+      </article>
+    </div>
   );
 }


### PR DESCRIPTION
## Summary
- Clean, distraction-free reader layout: 680px max-width, Georgia serif font, 1.8 line height
- Font size controls (A-/A+): 14px to 24px in 2px steps, persisted in localStorage
- Theme toggle: Light / Dark / System (respects OS `prefers-color-scheme`), persisted in localStorage
- Reading progress: blue bar at top + percentage indicator tracking scroll position
- Fixed controls bar with back navigation, font/theme controls, and progress
- Unparsed articles show fallback with link to original site
- Articles auto-marked as read when opened

## Test plan
- [ ] Open a saved article and verify reader layout (centered, serif font)
- [ ] Click A+ and A- to adjust font size, verify it persists across page loads
- [ ] Cycle through Light → Dark → System themes, verify each renders correctly
- [ ] Set theme to System, change OS dark mode preference, verify it updates
- [ ] Scroll through an article and verify progress bar fills and percentage updates
- [ ] Open an unparsed article and verify fallback link is shown
- [ ] Navigate back and verify article is marked as read in the list

Closes #4

🤖 Generated with [Claude Code](https://claude.ai/code)