### PR TITLE
Add article tagging with autocomplete

### DIFF
--- a/src/ReadWise.Api/Controllers/TagsController.cs
+++ b/src/ReadWise.Api/Controllers/TagsController.cs
@@ -1,0 +1,72 @@
+using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using ReadWise.Core.Interfaces;
+
+namespace ReadWise.Api.Controllers;
+
+[ApiController]
+[Authorize]
+[Route("api/[controller]")]
+public class TagsController : ControllerBase
+{
+    private readonly ITagRepository _tagRepository;
+    private readonly IArticleRepository _articleRepository;
+
+    public TagsController(ITagRepository tagRepository, IArticleRepository articleRepository)
+    {
+        _tagRepository = tagRepository;
+        _articleRepository = articleRepository;
+    }
+
+    private string CurrentUserId =>
+        User.FindFirstValue(ClaimTypes.NameIdentifier)
+        ?? User.FindFirstValue(JwtRegisteredClaimNames.Sub)
+        ?? throw new UnauthorizedAccessException();
+
+    /// <summary>Get all tags for the current user.</summary>
+    [HttpGet]
+    public async Task<ActionResult<IReadOnlyList<TagDto>>> GetAll()
+    {
+        var tags = await _tagRepository.GetAllByUserAsync(CurrentUserId);
+        return Ok(tags.Select(t => new TagDto(t.Id, t.Name)));
+    }
+
+    /// <summary>Delete a tag (removes from all articles).</summary>
+    [HttpDelete("{id:guid}")]
+    public async Task<IActionResult> Delete(Guid id)
+    {
+        await _tagRepository.DeleteAsync(id, CurrentUserId);
+        return NoContent();
+    }
+
+    /// <summary>Set the tags for an article (replaces all existing tags).</summary>
+    [HttpPut("/api/articles/{articleId:guid}/tags")]
+    public async Task<ActionResult<IReadOnlyList<TagDto>>> SetArticleTags(
+        Guid articleId,
+        [FromBody] SetArticleTagsRequest request)
+    {
+        var article = await _articleRepository.GetByIdAsync(articleId, CurrentUserId);
+        if (article is null) return NotFound();
+
+        await _tagRepository.SetArticleTagsAsync(articleId, CurrentUserId, request.Tags);
+
+        var tags = await _tagRepository.GetArticleTagsAsync(articleId);
+        return Ok(tags.Select(t => new TagDto(t.Id, t.Name)));
+    }
+
+    /// <summary>Get tags for a specific article.</summary>
+    [HttpGet("/api/articles/{articleId:guid}/tags")]
+    public async Task<ActionResult<IReadOnlyList<TagDto>>> GetArticleTags(Guid articleId)
+    {
+        var article = await _articleRepository.GetByIdAsync(articleId, CurrentUserId);
+        if (article is null) return NotFound();
+
+        var tags = await _tagRepository.GetArticleTagsAsync(articleId);
+        return Ok(tags.Select(t => new TagDto(t.Id, t.Name)));
+    }
+}
+
+public record TagDto(Guid Id, string Name);
+public record SetArticleTagsRequest(IReadOnlyList<string> Tags);

--- a/src/ReadWise.Api/Program.cs
+++ b/src/ReadWise.Api/Program.cs
@@ -11,7 +11,11 @@ using ReadWise.Infrastructure.Services;
 
 var builder = WebApplication.CreateBuilder(args);
 
-builder.Services.AddControllers();
+builder.Services.AddControllers()
+    .AddJsonOptions(options =>
+    {
+        options.JsonSerializerOptions.ReferenceHandler = System.Text.Json.Serialization.ReferenceHandler.IgnoreCycles;
+    });
 builder.Services.AddOpenApi();
 
 // Database - SQLite for development, SQL Server for production
@@ -64,6 +68,7 @@ builder.Services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
 builder.Services.AddAuthorization();
 builder.Services.AddScoped<TokenService>();
 builder.Services.AddScoped<IArticleRepository, ArticleRepository>();
+builder.Services.AddScoped<ITagRepository, TagRepository>();
 builder.Services.AddHttpClient<IArticleParser, SmartReaderArticleParser>(client =>
 {
     client.Timeout = TimeSpan.FromSeconds(30);

--- a/src/ReadWise.Core/Entities/Article.cs
+++ b/src/ReadWise.Core/Entities/Article.cs
@@ -20,4 +20,6 @@ public class Article
     public DateTime SavedAt { get; set; } = DateTime.UtcNow;
     public DateTime? ReadAt { get; set; }
     public DateTime? ArchivedAt { get; set; }
+
+    public ICollection<ArticleTag> ArticleTags { get; set; } = [];
 }

--- a/src/ReadWise.Core/Entities/ArticleTag.cs
+++ b/src/ReadWise.Core/Entities/ArticleTag.cs
@@ -1,0 +1,10 @@
+namespace ReadWise.Core.Entities;
+
+public class ArticleTag
+{
+    public Guid ArticleId { get; set; }
+    public Article Article { get; set; } = null!;
+
+    public Guid TagId { get; set; }
+    public Tag Tag { get; set; } = null!;
+}

--- a/src/ReadWise.Core/Entities/Tag.cs
+++ b/src/ReadWise.Core/Entities/Tag.cs
@@ -1,0 +1,11 @@
+namespace ReadWise.Core.Entities;
+
+public class Tag
+{
+    public Guid Id { get; set; }
+    public string UserId { get; set; } = string.Empty;
+    public string Name { get; set; } = string.Empty;
+    public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+
+    public ICollection<ArticleTag> ArticleTags { get; set; } = [];
+}

--- a/src/ReadWise.Core/Interfaces/ITagRepository.cs
+++ b/src/ReadWise.Core/Interfaces/ITagRepository.cs
@@ -1,0 +1,14 @@
+using ReadWise.Core.Entities;
+
+namespace ReadWise.Core.Interfaces;
+
+public interface ITagRepository
+{
+    Task<IReadOnlyList<Tag>> GetAllByUserAsync(string userId);
+    Task<Tag?> GetByIdAsync(Guid id, string userId);
+    Task<Tag?> GetByNameAsync(string name, string userId);
+    Task<Tag> CreateAsync(Tag tag);
+    Task DeleteAsync(Guid id, string userId);
+    Task SetArticleTagsAsync(Guid articleId, string userId, IReadOnlyList<string> tagNames);
+    Task<IReadOnlyList<Tag>> GetArticleTagsAsync(Guid articleId);
+}

--- a/src/ReadWise.Infrastructure/Data/ArticleRepository.cs
+++ b/src/ReadWise.Infrastructure/Data/ArticleRepository.cs
@@ -16,6 +16,8 @@ public class ArticleRepository : IArticleRepository
     public async Task<Article?> GetByIdAsync(Guid id, string userId)
     {
         return await _context.Articles
+            .Include(a => a.ArticleTags)
+                .ThenInclude(at => at.Tag)
             .FirstOrDefaultAsync(a => a.Id == id && a.UserId == userId);
     }
 
@@ -35,7 +37,10 @@ public class ArticleRepository : IArticleRepository
 
     public async Task<PagedResult<Article>> GetPagedByUserAsync(string userId, int page, int pageSize, ArticleStatus status = ArticleStatus.Default)
     {
-        var query = _context.Articles.Where(a => a.UserId == userId);
+        var query = _context.Articles
+            .Include(a => a.ArticleTags)
+                .ThenInclude(at => at.Tag)
+            .Where(a => a.UserId == userId);
 
         query = status switch
         {

--- a/src/ReadWise.Infrastructure/Data/ReadWiseDbContext.cs
+++ b/src/ReadWise.Infrastructure/Data/ReadWiseDbContext.cs
@@ -9,6 +9,8 @@ public class ReadWiseDbContext : IdentityDbContext<ApplicationUser>
     public ReadWiseDbContext(DbContextOptions<ReadWiseDbContext> options) : base(options) { }
 
     public DbSet<Article> Articles => Set<Article>();
+    public DbSet<Tag> Tags => Set<Tag>();
+    public DbSet<ArticleTag> ArticleTags => Set<ArticleTag>();
     public DbSet<RefreshToken> RefreshTokens => Set<RefreshToken>();
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
@@ -27,6 +29,33 @@ public class ReadWiseDbContext : IdentityDbContext<ApplicationUser>
             entity.HasOne<ApplicationUser>()
                 .WithMany(u => u.Articles)
                 .HasForeignKey(a => a.UserId)
+                .OnDelete(DeleteBehavior.Cascade);
+        });
+
+        modelBuilder.Entity<Tag>(entity =>
+        {
+            entity.HasKey(e => e.Id);
+            entity.HasIndex(e => new { e.UserId, e.Name }).IsUnique();
+            entity.Property(e => e.Name).HasMaxLength(50);
+
+            entity.HasOne<ApplicationUser>()
+                .WithMany()
+                .HasForeignKey(t => t.UserId)
+                .OnDelete(DeleteBehavior.Cascade);
+        });
+
+        modelBuilder.Entity<ArticleTag>(entity =>
+        {
+            entity.HasKey(e => new { e.ArticleId, e.TagId });
+
+            entity.HasOne(e => e.Article)
+                .WithMany(a => a.ArticleTags)
+                .HasForeignKey(e => e.ArticleId)
+                .OnDelete(DeleteBehavior.Cascade);
+
+            entity.HasOne(e => e.Tag)
+                .WithMany(t => t.ArticleTags)
+                .HasForeignKey(e => e.TagId)
                 .OnDelete(DeleteBehavior.Cascade);
         });
 

--- a/src/ReadWise.Infrastructure/Data/TagRepository.cs
+++ b/src/ReadWise.Infrastructure/Data/TagRepository.cs
@@ -1,0 +1,106 @@
+using Microsoft.EntityFrameworkCore;
+using ReadWise.Core.Entities;
+using ReadWise.Core.Interfaces;
+
+namespace ReadWise.Infrastructure.Data;
+
+public class TagRepository : ITagRepository
+{
+    private readonly ReadWiseDbContext _context;
+
+    public TagRepository(ReadWiseDbContext context)
+    {
+        _context = context;
+    }
+
+    public async Task<IReadOnlyList<Tag>> GetAllByUserAsync(string userId)
+    {
+        return await _context.Tags
+            .Where(t => t.UserId == userId)
+            .OrderBy(t => t.Name)
+            .ToListAsync();
+    }
+
+    public async Task<Tag?> GetByIdAsync(Guid id, string userId)
+    {
+        return await _context.Tags
+            .FirstOrDefaultAsync(t => t.Id == id && t.UserId == userId);
+    }
+
+    public async Task<Tag?> GetByNameAsync(string name, string userId)
+    {
+        var normalized = name.Trim().ToLowerInvariant();
+        return await _context.Tags
+            .FirstOrDefaultAsync(t => t.Name == normalized && t.UserId == userId);
+    }
+
+    public async Task<Tag> CreateAsync(Tag tag)
+    {
+        tag.Name = tag.Name.Trim().ToLowerInvariant();
+        _context.Tags.Add(tag);
+        await _context.SaveChangesAsync();
+        return tag;
+    }
+
+    public async Task DeleteAsync(Guid id, string userId)
+    {
+        var tag = await GetByIdAsync(id, userId);
+        if (tag is not null)
+        {
+            _context.Tags.Remove(tag);
+            await _context.SaveChangesAsync();
+        }
+    }
+
+    public async Task SetArticleTagsAsync(Guid articleId, string userId, IReadOnlyList<string> tagNames)
+    {
+        // Remove existing tags for this article
+        var existing = await _context.ArticleTags
+            .Where(at => at.ArticleId == articleId)
+            .ToListAsync();
+        _context.ArticleTags.RemoveRange(existing);
+
+        // Normalize and limit tag names
+        var normalized = tagNames
+            .Select(n => n.Trim().ToLowerInvariant())
+            .Where(n => n.Length > 0 && n.Length <= 50)
+            .Distinct()
+            .Take(10)
+            .ToList();
+
+        foreach (var name in normalized)
+        {
+            // Find or create tag
+            var tag = await _context.Tags
+                .FirstOrDefaultAsync(t => t.Name == name && t.UserId == userId);
+
+            if (tag is null)
+            {
+                tag = new Tag
+                {
+                    Id = Guid.NewGuid(),
+                    UserId = userId,
+                    Name = name,
+                };
+                _context.Tags.Add(tag);
+            }
+
+            _context.ArticleTags.Add(new ArticleTag
+            {
+                ArticleId = articleId,
+                TagId = tag.Id,
+            });
+        }
+
+        await _context.SaveChangesAsync();
+    }
+
+    public async Task<IReadOnlyList<Tag>> GetArticleTagsAsync(Guid articleId)
+    {
+        return await _context.ArticleTags
+            .Where(at => at.ArticleId == articleId)
+            .Select(at => at.Tag)
+            .OrderBy(t => t.Name)
+            .ToListAsync();
+    }
+}

--- a/src/web/src/components/TagEditor.tsx
+++ b/src/web/src/components/TagEditor.tsx
@@ -1,0 +1,229 @@
+import { useState, useEffect, useRef } from 'react';
+import type { Tag } from '../types/article';
+import { tagsApi } from '../services/api';
+
+interface TagEditorProps {
+  articleId: string;
+  tags: Tag[];
+  onTagsChange: (tags: Tag[]) => void;
+}
+
+export function TagEditor({ articleId, tags, onTagsChange }: TagEditorProps) {
+  const [editing, setEditing] = useState(false);
+  const [input, setInput] = useState('');
+  const [suggestions, setSuggestions] = useState<Tag[]>([]);
+  const [allTags, setAllTags] = useState<Tag[]>([]);
+  const [highlightIndex, setHighlightIndex] = useState(-1);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (editing) {
+      tagsApi.getAll().then(setAllTags);
+      inputRef.current?.focus();
+    }
+  }, [editing]);
+
+  useEffect(() => {
+    if (!input.trim()) {
+      setSuggestions([]);
+      setHighlightIndex(-1);
+      return;
+    }
+    const lower = input.toLowerCase();
+    const currentNames = new Set(tags.map((t) => t.name));
+    const filtered = allTags
+      .filter((t) => t.name.includes(lower) && !currentNames.has(t.name))
+      .slice(0, 5);
+    setSuggestions(filtered);
+    setHighlightIndex(-1);
+  }, [input, allTags, tags]);
+
+  const addTag = async (name: string) => {
+    const trimmed = name.trim().toLowerCase();
+    if (!trimmed || trimmed.length > 50) return;
+    if (tags.length >= 10) return;
+    if (tags.some((t) => t.name === trimmed)) return;
+
+    const newTagNames = [...tags.map((t) => t.name), trimmed];
+    const { articlesApi } = await import('../services/api');
+    const updatedTags = await articlesApi.setTags(articleId, newTagNames);
+    onTagsChange(updatedTags);
+    setInput('');
+    setSuggestions([]);
+  };
+
+  const removeTag = async (name: string) => {
+    const newTagNames = tags.filter((t) => t.name !== name).map((t) => t.name);
+    const { articlesApi } = await import('../services/api');
+    const updatedTags = await articlesApi.setTags(articleId, newTagNames);
+    onTagsChange(updatedTags);
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'Enter') {
+      e.preventDefault();
+      if (highlightIndex >= 0 && highlightIndex < suggestions.length) {
+        addTag(suggestions[highlightIndex].name);
+      } else if (input.trim()) {
+        addTag(input);
+      }
+    } else if (e.key === 'Escape') {
+      setEditing(false);
+      setInput('');
+    } else if (e.key === 'ArrowDown') {
+      e.preventDefault();
+      setHighlightIndex((i) => Math.min(i + 1, suggestions.length - 1));
+    } else if (e.key === 'ArrowUp') {
+      e.preventDefault();
+      setHighlightIndex((i) => Math.max(i - 1, 0));
+    } else if (e.key === 'Backspace' && !input && tags.length > 0) {
+      removeTag(tags[tags.length - 1].name);
+    }
+  };
+
+  if (!editing) {
+    return (
+      <div
+        style={{ display: 'flex', flexWrap: 'wrap', gap: '0.25rem', alignItems: 'center' }}
+        onClick={(e) => e.stopPropagation()}
+      >
+        {tags.map((tag) => (
+          <span
+            key={tag.id}
+            style={{
+              background: '#e8f0fe',
+              color: '#1a73e8',
+              padding: '0.1rem 0.4rem',
+              borderRadius: 3,
+              fontSize: '0.75rem',
+            }}
+          >
+            {tag.name}
+          </span>
+        ))}
+        <button
+          onClick={(e) => {
+            e.preventDefault();
+            e.stopPropagation();
+            setEditing(true);
+          }}
+          style={{
+            background: 'none',
+            border: '1px dashed #ccc',
+            borderRadius: 3,
+            padding: '0.1rem 0.35rem',
+            fontSize: '0.75rem',
+            color: '#999',
+            cursor: 'pointer',
+          }}
+        >
+          + tag
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <div
+      style={{ position: 'relative' }}
+      onClick={(e) => e.stopPropagation()}
+    >
+      <div
+        style={{
+          display: 'flex',
+          flexWrap: 'wrap',
+          gap: '0.25rem',
+          alignItems: 'center',
+          border: '1px solid #4a9eff',
+          borderRadius: 4,
+          padding: '0.25rem',
+          background: '#fff',
+        }}
+      >
+        {tags.map((tag) => (
+          <span
+            key={tag.id}
+            style={{
+              background: '#e8f0fe',
+              color: '#1a73e8',
+              padding: '0.1rem 0.4rem',
+              borderRadius: 3,
+              fontSize: '0.75rem',
+              display: 'flex',
+              alignItems: 'center',
+              gap: '0.2rem',
+            }}
+          >
+            {tag.name}
+            <button
+              onClick={() => removeTag(tag.name)}
+              style={{
+                background: 'none',
+                border: 'none',
+                cursor: 'pointer',
+                padding: 0,
+                fontSize: '0.8rem',
+                color: '#1a73e8',
+                lineHeight: 1,
+              }}
+            >
+              &times;
+            </button>
+          </span>
+        ))}
+        <input
+          ref={inputRef}
+          value={input}
+          onChange={(e) => setInput(e.target.value)}
+          onKeyDown={handleKeyDown}
+          onBlur={() => {
+            // Delay to allow click on suggestion
+            setTimeout(() => setEditing(false), 150);
+          }}
+          placeholder={tags.length >= 10 ? 'Max tags reached' : 'Add tag...'}
+          disabled={tags.length >= 10}
+          maxLength={50}
+          style={{
+            border: 'none',
+            outline: 'none',
+            fontSize: '0.8rem',
+            flex: 1,
+            minWidth: 60,
+            padding: '0.1rem',
+          }}
+        />
+      </div>
+
+      {suggestions.length > 0 && (
+        <div
+          style={{
+            position: 'absolute',
+            left: 0,
+            right: 0,
+            top: '100%',
+            background: '#fff',
+            border: '1px solid #ddd',
+            borderRadius: 4,
+            boxShadow: '0 2px 8px rgba(0,0,0,0.12)',
+            zIndex: 20,
+          }}
+        >
+          {suggestions.map((tag, i) => (
+            <div
+              key={tag.id}
+              onClick={() => addTag(tag.name)}
+              style={{
+                padding: '0.35rem 0.5rem',
+                cursor: 'pointer',
+                fontSize: '0.85rem',
+                background: i === highlightIndex ? '#f0f0f0' : 'transparent',
+              }}
+            >
+              {tag.name}
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/web/src/pages/HomePage.tsx
+++ b/src/web/src/pages/HomePage.tsx
@@ -1,8 +1,9 @@
 import { useEffect, useState, useCallback } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
-import type { Article } from '../types/article';
+import type { Article, Tag } from '../types/article';
 import { articlesApi } from '../services/api';
 import { useAuth } from '../hooks/useAuthHook';
+import { TagEditor } from '../components/TagEditor';
 
 type StatusTab = 'default' | 'archived' | 'favorites';
 
@@ -111,6 +112,22 @@ export function HomePage() {
     setConfirmDeleteId(null);
   };
 
+  const getArticleTags = (article: Article): Tag[] => {
+    return (article.articleTags ?? [])
+      .map((at) => at.tag)
+      .filter(Boolean);
+  };
+
+  const handleTagsChange = (articleId: string, newTags: Tag[]) => {
+    setArticles((prev) =>
+      prev.map((a) =>
+        a.id === articleId
+          ? { ...a, articleTags: newTags.map((t) => ({ articleId, tagId: t.id, tag: t })) }
+          : a,
+      ),
+    );
+  };
+
   const formatDate = (dateString: string) => {
     return new Date(dateString).toLocaleDateString(undefined, {
       month: 'short',
@@ -203,39 +220,48 @@ export function HomePage() {
                 }}
               >
                 <div style={{ display: 'flex', alignItems: 'flex-start', gap: '0.5rem' }}>
-                  <Link
-                    to={`/read/${article.id}`}
-                    style={{ textDecoration: 'none', color: 'inherit', flex: 1 }}
-                  >
-                    <div
-                      style={{
-                        fontWeight: 600,
-                        fontSize: '1.1rem',
-                        marginBottom: '0.25rem',
-                      }}
+                  <div style={{ flex: 1 }}>
+                    <Link
+                      to={`/read/${article.id}`}
+                      style={{ textDecoration: 'none', color: 'inherit', display: 'block' }}
                     >
-                      {article.isFavorite && (
-                        <span style={{ color: '#f5a623', marginRight: '0.4rem' }}>&#9733;</span>
-                      )}
-                      {article.title}
-                    </div>
-                    <div style={{ color: '#666', fontSize: '0.85rem' }}>
-                      {article.domain}
-                      {article.estimatedReadingTimeMinutes > 0 && (
-                        <> &middot; {article.estimatedReadingTimeMinutes} min read</>
-                      )}
-                      {!article.isContentParsed && <> &middot; Link only</>}
-                      <> &middot; {formatDate(article.savedAt)}</>
-                    </div>
-                    {article.excerpt && (
                       <div
-                        style={{ color: '#888', fontSize: '0.85rem', marginTop: '0.25rem' }}
+                        style={{
+                          fontWeight: 600,
+                          fontSize: '1.1rem',
+                          marginBottom: '0.25rem',
+                        }}
                       >
-                        {article.excerpt.slice(0, 150)}
-                        {article.excerpt.length > 150 && '...'}
+                        {article.isFavorite && (
+                          <span style={{ color: '#f5a623', marginRight: '0.4rem' }}>&#9733;</span>
+                        )}
+                        {article.title}
                       </div>
-                    )}
-                  </Link>
+                      <div style={{ color: '#666', fontSize: '0.85rem' }}>
+                        {article.domain}
+                        {article.estimatedReadingTimeMinutes > 0 && (
+                          <> &middot; {article.estimatedReadingTimeMinutes} min read</>
+                        )}
+                        {!article.isContentParsed && <> &middot; Link only</>}
+                        <> &middot; {formatDate(article.savedAt)}</>
+                      </div>
+                      {article.excerpt && (
+                        <div
+                          style={{ color: '#888', fontSize: '0.85rem', marginTop: '0.25rem' }}
+                        >
+                          {article.excerpt.slice(0, 150)}
+                          {article.excerpt.length > 150 && '...'}
+                        </div>
+                      )}
+                    </Link>
+                    <div style={{ marginTop: '0.35rem' }}>
+                      <TagEditor
+                        articleId={article.id}
+                        tags={getArticleTags(article)}
+                        onTagsChange={(newTags) => handleTagsChange(article.id, newTags)}
+                      />
+                    </div>
+                  </div>
 
                   {/* Action buttons */}
                   <div style={{ display: 'flex', gap: '0.25rem', alignItems: 'center', flexShrink: 0 }}>

--- a/src/web/src/pages/ReaderPage.tsx
+++ b/src/web/src/pages/ReaderPage.tsx
@@ -1,9 +1,10 @@
 import { useEffect, useState } from 'react';
 import { useParams, Link, useNavigate } from 'react-router-dom';
-import type { Article } from '../types/article';
+import type { Article, Tag } from '../types/article';
 import { articlesApi } from '../services/api';
 import { useReaderPreferences } from '../hooks/useReaderPreferences';
 import { useReadingProgress } from '../hooks/useReadingProgress';
+import { TagEditor } from '../components/TagEditor';
 
 const themeStyles = {
   light: { background: '#ffffff', color: '#1a1a1a', metaColor: '#666', controlBg: '#f5f5f5' },
@@ -38,6 +39,20 @@ export function ReaderPage() {
       })
       .finally(() => setLoading(false));
   }, [id]);
+
+  const getArticleTags = (): Tag[] => {
+    return (article?.articleTags ?? [])
+      .map((at) => at.tag)
+      .filter(Boolean);
+  };
+
+  const handleTagsChange = (newTags: Tag[]) => {
+    if (!article) return;
+    setArticle({
+      ...article,
+      articleTags: newTags.map((t) => ({ articleId: article.id, tagId: t.id, tag: t })),
+    });
+  };
 
   const handleToggleFavorite = async () => {
     if (!article || !id) return;
@@ -200,6 +215,13 @@ export function ReaderPage() {
             {article.estimatedReadingTimeMinutes > 0 && (
               <span> &middot; {article.estimatedReadingTimeMinutes} min read</span>
             )}
+          </div>
+          <div style={{ marginTop: '0.75rem' }}>
+            <TagEditor
+              articleId={article.id}
+              tags={getArticleTags()}
+              onTagsChange={handleTagsChange}
+            />
           </div>
         </header>
 

--- a/src/web/src/services/api.ts
+++ b/src/web/src/services/api.ts
@@ -1,4 +1,4 @@
-import type { Article, CreateArticleRequest } from '../types/article';
+import type { Article, CreateArticleRequest, Tag } from '../types/article';
 import type { AuthResponse, LoginRequest, RegisterRequest } from '../types/auth';
 
 const BASE_URL = '/api';
@@ -150,4 +150,16 @@ export const articlesApi = {
     request<void>(`/articles/${id}/archive`, { method: 'PATCH' }),
   toggleFavorite: (id: string) =>
     request<void>(`/articles/${id}/favorite`, { method: 'PATCH' }),
+  setTags: (id: string, tags: string[]) =>
+    request<Tag[]>(`/articles/${id}/tags`, {
+      method: 'PUT',
+      body: JSON.stringify({ tags }),
+    }),
+  getTags: (id: string) =>
+    request<Tag[]>(`/articles/${id}/tags`),
+};
+
+export const tagsApi = {
+  getAll: () => request<Tag[]>('/tags'),
+  delete: (id: string) => request<void>(`/tags/${id}`, { method: 'DELETE' }),
 };

--- a/src/web/src/types/article.ts
+++ b/src/web/src/types/article.ts
@@ -1,3 +1,14 @@
+export interface Tag {
+  id: string;
+  name: string;
+}
+
+export interface ArticleTag {
+  articleId: string;
+  tagId: string;
+  tag: Tag;
+}
+
 export interface Article {
   id: string;
   userId: string;
@@ -17,6 +28,7 @@ export interface Article {
   savedAt: string;
   readAt?: string;
   archivedAt?: string;
+  articleTags?: ArticleTag[];
 }
 
 export interface CreateArticleRequest {


### PR DESCRIPTION
## Summary
- **Tag entity** with user-scoped, case-insensitive names (max 50 chars, max 10 per article)
- **API endpoints**: `GET /api/tags`, `DELETE /api/tags/{id}`, `PUT /api/articles/{id}/tags`, `GET /api/articles/{id}/tags`
- **TagEditor component** with inline editing, autocomplete suggestions from existing tags, keyboard navigation
- Tag chips displayed on article cards in home page list and in reader view header
- Tags auto-created on first use, normalized to lowercase

## Test plan
- [ ] Add tags to an article from the home page using the "+ tag" button
- [ ] Verify autocomplete shows existing tags as suggestions
- [ ] Verify tags are persisted and appear after page refresh
- [ ] Add tags from the reader view header
- [ ] Remove tags using the x button in edit mode
- [ ] Verify 10-tag limit is enforced
- [ ] Verify tag names are case-insensitive (adding "React" and "react" results in one tag)
- [ ] Verify keyboard navigation works (Enter to add, Escape to cancel, Backspace to remove last)

Closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)