### PR TITLE
Add search, tag filter, and status tabs

### DIFF
--- a/src/ReadWise.Core/Interfaces/IArticleRepository.cs
+++ b/src/ReadWise.Core/Interfaces/IArticleRepository.cs
@@ -9,14 +9,24 @@ public enum ArticleStatus
     Default,
     Archived,
     Favorites,
+    Unread,
 }
+
+public record ArticleQuery(
+    string UserId,
+    int Page = 1,
+    int PageSize = 20,
+    ArticleStatus Status = ArticleStatus.Default,
+    string? Search = null,
+    IReadOnlyList<string>? Tags = null
+);
 
 public interface IArticleRepository
 {
     Task<Article?> GetByIdAsync(Guid id, string userId);
     Task<Article?> GetByUrlAsync(string url, string userId);
     Task<IReadOnlyList<Article>> GetAllByUserAsync(string userId);
-    Task<PagedResult<Article>> GetPagedByUserAsync(string userId, int page, int pageSize, ArticleStatus status = ArticleStatus.Default);
+    Task<PagedResult<Article>> GetPagedAsync(ArticleQuery query);
     Task<Article> AddAsync(Article article);
     Task UpdateAsync(Article article);
     Task DeleteAsync(Guid id, string userId);

--- a/src/web/src/components/TagEditor.tsx
+++ b/src/web/src/components/TagEditor.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useRef } from 'react';
 import type { Tag } from '../types/article';
-import { tagsApi } from '../services/api';
+import { tagsApi, articlesApi } from '../services/api';
 
 interface TagEditorProps {
   articleId: string;
@@ -45,7 +45,6 @@ export function TagEditor({ articleId, tags, onTagsChange }: TagEditorProps) {
     if (tags.some((t) => t.name === trimmed)) return;
 
     const newTagNames = [...tags.map((t) => t.name), trimmed];
-    const { articlesApi } = await import('../services/api');
     const updatedTags = await articlesApi.setTags(articleId, newTagNames);
     onTagsChange(updatedTags);
     setInput('');
@@ -54,7 +53,6 @@ export function TagEditor({ articleId, tags, onTagsChange }: TagEditorProps) {
 
   const removeTag = async (name: string) => {
     const newTagNames = tags.filter((t) => t.name !== name).map((t) => t.name);
-    const { articlesApi } = await import('../services/api');
     const updatedTags = await articlesApi.setTags(articleId, newTagNames);
     onTagsChange(updatedTags);
   };

--- a/src/web/src/components/TagEditor.tsx
+++ b/src/web/src/components/TagEditor.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef } from 'react';
+import { useState, useEffect, useRef, useMemo } from 'react';
 import type { Tag } from '../types/article';
 import { tagsApi, articlesApi } from '../services/api';
 
@@ -11,7 +11,6 @@ interface TagEditorProps {
 export function TagEditor({ articleId, tags, onTagsChange }: TagEditorProps) {
   const [editing, setEditing] = useState(false);
   const [input, setInput] = useState('');
-  const [suggestions, setSuggestions] = useState<Tag[]>([]);
   const [allTags, setAllTags] = useState<Tag[]>([]);
   const [highlightIndex, setHighlightIndex] = useState(-1);
   const inputRef = useRef<HTMLInputElement>(null);
@@ -23,19 +22,13 @@ export function TagEditor({ articleId, tags, onTagsChange }: TagEditorProps) {
     }
   }, [editing]);
 
-  useEffect(() => {
-    if (!input.trim()) {
-      setSuggestions([]);
-      setHighlightIndex(-1);
-      return;
-    }
+  const suggestions = useMemo(() => {
+    if (!input.trim()) return [];
     const lower = input.toLowerCase();
     const currentNames = new Set(tags.map((t) => t.name));
-    const filtered = allTags
+    return allTags
       .filter((t) => t.name.includes(lower) && !currentNames.has(t.name))
       .slice(0, 5);
-    setSuggestions(filtered);
-    setHighlightIndex(-1);
   }, [input, allTags, tags]);
 
   const addTag = async (name: string) => {
@@ -48,7 +41,7 @@ export function TagEditor({ articleId, tags, onTagsChange }: TagEditorProps) {
     const updatedTags = await articlesApi.setTags(articleId, newTagNames);
     onTagsChange(updatedTags);
     setInput('');
-    setSuggestions([]);
+    setHighlightIndex(-1);
   };
 
   const removeTag = async (name: string) => {

--- a/src/web/src/pages/HomePage.tsx
+++ b/src/web/src/pages/HomePage.tsx
@@ -31,7 +31,7 @@ export function HomePage() {
   const [searchQuery, setSearchQuery] = useState('');
   const [allUserTags, setAllUserTags] = useState<Tag[]>([]);
   const [selectedTags, setSelectedTags] = useState<string[]>([]);
-  const debounceRef = useRef<ReturnType<typeof setTimeout>>();
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
   const pageSize = 20;
 
   const totalPages = Math.ceil(totalCount / pageSize);

--- a/src/web/src/services/api.ts
+++ b/src/web/src/services/api.ts
@@ -131,9 +131,11 @@ export interface PagedResult<T> {
 }
 
 export const articlesApi = {
-  getAll: (page = 1, pageSize = 20, status?: string) => {
+  getAll: (page = 1, pageSize = 20, status?: string, search?: string, tags?: string[]) => {
     const params = new URLSearchParams({ page: String(page), pageSize: String(pageSize) });
     if (status) params.set('status', status);
+    if (search) params.set('search', search);
+    if (tags && tags.length > 0) params.set('tags', tags.join(','));
     return request<PagedResult<Article>>(`/articles?${params}`);
   },
   getById: (id: string) => request<Article>(`/articles/${id}`),


### PR DESCRIPTION
## Summary
- **Search bar** with 300ms debounced input — searches article title and excerpt
- **Tag filter chips** — click tags to filter articles (OR logic: matches any selected tag)
- **Status tabs** updated to: All, Unread, Favorites, Archived (mutually exclusive)
- Backend `ArticleQuery` record consolidates all filter parameters
- `GET /api/articles` now accepts `?search=`, `?tags=tag1,tag2`, `?status=unread` params

## Test plan
- [ ] Type in search bar and verify results filter after 300ms debounce
- [ ] Search for a word in an article title — verify it appears
- [ ] Search for a word only in the excerpt — verify it still matches
- [ ] Click tag filter chips and verify articles are filtered by tag
- [ ] Select multiple tags and verify OR logic (articles with ANY selected tag shown)
- [ ] Click "Clear filters" to remove tag filter
- [ ] Switch between All, Unread, Favorites, Archived tabs
- [ ] Combine search + tag filter + status tab and verify all filters apply together
- [ ] Save a new article and verify filters reset to defaults

Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)